### PR TITLE
Add CSV re-export with sensible file names

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
   getExpectedExcessCost,
   getPremiumCostDataStatus
 } from "@/lib/utils";
+import { getExportFilesForUploadedCsv } from "@/lib/csv-export";
 import { MonthSelector } from "@/components/MonthSelector";
 import { UserSearch } from "@/components/UserSearch";
 import { AICCostChart } from "@/components/AICCostChart";
@@ -532,6 +533,7 @@ function App() {
   const [modelSortDirection, setModelSortDirection] = useState<'asc' | 'desc'>('desc');
   const [totalLicensedUsers, setTotalLicensedUsers] = useState<number | null>(null);
   const [demoMode, setDemoMode] = useState(false);
+  const [uploadedFiles, setUploadedFiles] = useState<{ name: string; content: string }[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Anonymized user map: maps real user names to anonymous "User000N" labels, stable across month selections
@@ -774,6 +776,7 @@ function App() {
     setLastDateAvailable(null);
     setDailyOveruserData([]);
     setDemoMode(false);
+    setUploadedFiles([]);
   }, []);
 
   const processFiles = useCallback((files: File[]) => {
@@ -798,6 +801,8 @@ function App() {
         const allData: CopilotUsageData[] = [];
         const seenKeys = new Set<string>();
 
+        const uploadedFilesForExport: { name: string; content: string }[] = [];
+
         for (let i = 0; i < contents.length; i++) {
           const csvContent = contents[i];
           const fileName = files[i].name;
@@ -811,6 +816,7 @@ function App() {
             }
 
             const parsedData = parseCSV(csvContent);
+            uploadedFilesForExport.push({ name: fileName, content: csvContent });
 
             for (const record of parsedData) {
               const key = `${record.timestamp.toISOString()}_${record.user}_${record.model}_${record.requestsUsed}`;
@@ -830,6 +836,7 @@ function App() {
         }
 
         setRawData(allData);
+        setUploadedFiles(uploadedFilesForExport);
 
         const months = getAvailableMonths(allData);
         setAvailableMonths(months);
@@ -876,6 +883,33 @@ function App() {
     if (isProcessing) return;
     fileInputRef.current?.click();
   };
+
+  const handleExportUploadedFiles = useCallback(() => {
+    if (uploadedFiles.length === 0) return;
+
+    let exportedCount = 0;
+    for (const file of uploadedFiles) {
+      const exportFiles = getExportFilesForUploadedCsv(file.content);
+      for (const exportFile of exportFiles) {
+        const blob = new Blob([exportFile.content], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = exportFile.fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        exportedCount++;
+      }
+    }
+
+    if (exportedCount === 0) {
+      toast.error('No data available to export from the uploaded files.');
+    } else {
+      toast.success(`Exported ${exportedCount} file(s).`);
+    }
+  }, [uploadedFiles]);
   
   const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
     if (isProcessing) return;
@@ -1208,6 +1242,18 @@ function App() {
               >
                 <Upload size={14} />
                 Upload New Files
+              </Button>
+            )}
+            {uploadedFiles.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleExportUploadedFiles}
+                disabled={isProcessing}
+                className="flex items-center gap-2"
+                title="Download the uploaded CSV data back out as separate files, one per month, named <identifier>-YYYYMM.csv"
+              >
+                Export Uploaded Files
               </Button>
             )}
             <Button variant="outline" size="sm" asChild>

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -1,0 +1,140 @@
+/**
+ * Utilities for re-exporting uploaded CSV files with sensible file names.
+ *
+ * Background: the CSV formats supported by this app (see `parseCSV` in `utils.ts`)
+ * do NOT contain an "enterprise" column. The only organization-level identifiers
+ * available are `organization` (new format) and `cost_center_name` (new format).
+ * The legacy format has neither. We therefore pick the best available identifier
+ * per file, in this priority order: organization > cost_center_name > a generic
+ * fallback prefix ("copilot-usage").
+ *
+ * Each uploaded file is split into one CSV per calendar month found in its data
+ * (using the same date/timestamp column the file already has), preserving the
+ * original header and raw row text exactly as uploaded. This keeps the export
+ * simple: no re-serialization of parsed values, just filtering of original lines.
+ */
+
+/** Splits a raw CSV line into its comma-separated fields, honoring quoted fields. */
+function splitCsvLine(line: string): string[] {
+  const matches = line.match(/("([^"]*)"|([^,]*))(,|$)/g);
+  if (!matches) return [];
+  return matches.map(m => {
+    let processed = m.endsWith(',') ? m.slice(0, -1) : m;
+    processed = processed.replace(/^"(.*)"$/, '$1');
+    return processed.trim();
+  });
+}
+
+const DATE_HEADER_CANDIDATES = ['date', 'timestamp'];
+const ORG_HEADER_CANDIDATES = ['organization'];
+const COST_CENTER_HEADER_CANDIDATES = ['cost_center_name'];
+
+export const FALLBACK_FILE_PREFIX = 'copilot-usage';
+
+function findHeaderIndex(headers: string[], candidates: string[]): number {
+  const lowerHeaders = headers.map(h => h.toLowerCase());
+  for (const candidate of candidates) {
+    const idx = lowerHeaders.indexOf(candidate);
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+export interface CsvMonthPart {
+  /** Month in YYYYMM format, e.g. "202506" */
+  month: string;
+  /** Full CSV content for this month, including the original header row */
+  content: string;
+}
+
+/**
+ * Splits raw CSV content into one part per calendar month present in the data,
+ * based on the file's date/timestamp column. The original header and row text
+ * are preserved unchanged. Rows with an unparsable date are skipped.
+ */
+export function splitCsvByMonth(csvContent: string): CsvMonthPart[] {
+  const lines = csvContent.split(/\r?\n/);
+  const nonEmptyLines = lines.filter(l => l.trim().length > 0);
+  if (nonEmptyLines.length < 2) return [];
+
+  const headerLine = nonEmptyLines[0];
+  const headers = splitCsvLine(headerLine);
+  const dateIdx = findHeaderIndex(headers, DATE_HEADER_CANDIDATES);
+  if (dateIdx === -1) return [];
+
+  const rowsByMonth = new Map<string, string[]>();
+
+  for (let i = 1; i < nonEmptyLines.length; i++) {
+    const line = nonEmptyLines[i];
+    const fields = splitCsvLine(line);
+    const dateStr = fields[dateIdx];
+    if (!dateStr) continue;
+    const parsed = new Date(dateStr);
+    if (isNaN(parsed.getTime())) continue;
+
+    const month = `${parsed.getFullYear()}${String(parsed.getMonth() + 1).padStart(2, '0')}`;
+    if (!rowsByMonth.has(month)) rowsByMonth.set(month, []);
+    rowsByMonth.get(month)!.push(line);
+  }
+
+  return Array.from(rowsByMonth.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, rows]) => ({
+      month,
+      content: [headerLine, ...rows].join('\n'),
+    }));
+}
+
+/**
+ * Determines the best available identifier for a CSV file's naming prefix.
+ * Priority: organization column value > cost_center_name column value > fallback.
+ * Returns the first non-empty value found across data rows for the preferred column.
+ */
+export function getFileIdentifier(csvContent: string): string {
+  const lines = csvContent.split(/\r?\n/).filter(l => l.trim().length > 0);
+  if (lines.length < 2) return FALLBACK_FILE_PREFIX;
+
+  const headers = splitCsvLine(lines[0]);
+  const orgIdx = findHeaderIndex(headers, ORG_HEADER_CANDIDATES);
+  const costCenterIdx = findHeaderIndex(headers, COST_CENTER_HEADER_CANDIDATES);
+
+  const firstNonEmptyValue = (idx: number): string | undefined => {
+    if (idx === -1) return undefined;
+    for (let i = 1; i < lines.length; i++) {
+      const fields = splitCsvLine(lines[i]);
+      const value = fields[idx]?.trim();
+      if (value) return value;
+    }
+    return undefined;
+  };
+
+  return firstNonEmptyValue(orgIdx) ?? firstNonEmptyValue(costCenterIdx) ?? FALLBACK_FILE_PREFIX;
+}
+
+/** Sanitizes a string for safe use in a file name. */
+function sanitizeForFileName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || FALLBACK_FILE_PREFIX;
+}
+
+export function buildExportFileName(identifier: string, month: string): string {
+  return `${sanitizeForFileName(identifier)}-${month}.csv`;
+}
+
+export interface ExportedCsvFile {
+  fileName: string;
+  content: string;
+}
+
+/**
+ * Given the raw content of one originally uploaded CSV file, produces the list
+ * of export files: one per calendar month present in the data, named
+ * `<identifier>-YYYYMM.csv`.
+ */
+export function getExportFilesForUploadedCsv(csvContent: string): ExportedCsvFile[] {
+  const identifier = getFileIdentifier(csvContent);
+  const monthParts = splitCsvByMonth(csvContent);
+  return monthParts.map(part => ({
+    fileName: buildExportFileName(identifier, part.month),
+    content: part.content,
+  }));
+}

--- a/src/test/csv-export.test.ts
+++ b/src/test/csv-export.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  splitCsvByMonth,
+  getFileIdentifier,
+  buildExportFileName,
+  getExportFilesForUploadedCsv,
+  FALLBACK_FILE_PREFIX,
+} from '@/lib/csv-export'
+
+describe('csv-export', () => {
+  describe('getFileIdentifier', () => {
+    it('uses organization column when present', () => {
+      const csv = `"date","username","organization","cost_center_name"
+"2026-06-01","user1","my-org","cc-1"`
+      expect(getFileIdentifier(csv)).toBe('my-org')
+    })
+
+    it('falls back to cost_center_name when organization is empty', () => {
+      const csv = `"date","username","organization","cost_center_name"
+"2026-06-01","user1","","cc-1"`
+      expect(getFileIdentifier(csv)).toBe('cc-1')
+    })
+
+    it('falls back to generic prefix when neither organization nor cost_center_name exist', () => {
+      const csv = `"Timestamp","User","Model","Requests Used","Exceeds Monthly Quota","Total Monthly Quota"
+"2024-01-01T00:00:00Z","user1","gpt-4","1.5","false","100"`
+      expect(getFileIdentifier(csv)).toBe(FALLBACK_FILE_PREFIX)
+    })
+
+    it('falls back to generic prefix when both columns are empty', () => {
+      const csv = `"date","username","organization","cost_center_name"
+"2026-06-01","user1","",""`
+      expect(getFileIdentifier(csv)).toBe(FALLBACK_FILE_PREFIX)
+    })
+  })
+
+  describe('splitCsvByMonth', () => {
+    it('splits rows into groups by month, preserving header', () => {
+      const csv = `"date","username","organization"
+"2026-06-01","user1","my-org"
+"2026-06-15","user2","my-org"
+"2026-07-01","user3","my-org"`
+      const parts = splitCsvByMonth(csv)
+      expect(parts).toHaveLength(2)
+      expect(parts[0].month).toBe('202606')
+      expect(parts[0].content).toContain('"date","username","organization"')
+      expect(parts[0].content.split('\n')).toHaveLength(3) // header + 2 rows
+      expect(parts[1].month).toBe('202607')
+      expect(parts[1].content.split('\n')).toHaveLength(2) // header + 1 row
+    })
+
+    it('returns a single part when all rows are in the same month', () => {
+      const csv = `"Timestamp","User","Model","Requests Used","Exceeds Monthly Quota","Total Monthly Quota"
+"2024-01-01T00:00:00Z","user1","gpt-4","1.5","false","100"
+"2024-01-15T00:00:00Z","user2","gpt-4","2","false","100"`
+      const parts = splitCsvByMonth(csv)
+      expect(parts).toHaveLength(1)
+      expect(parts[0].month).toBe('202401')
+    })
+
+    it('returns empty array when there is no date-like column', () => {
+      const csv = `"foo","bar"
+"1","2"`
+      expect(splitCsvByMonth(csv)).toEqual([])
+    })
+
+    it('returns empty array for header-only CSV', () => {
+      const csv = `"date","username"`
+      expect(splitCsvByMonth(csv)).toEqual([])
+    })
+
+    it('skips rows with unparsable dates', () => {
+      const csv = `"date","username"
+"not-a-date","user1"
+"2026-06-01","user2"`
+      const parts = splitCsvByMonth(csv)
+      expect(parts).toHaveLength(1)
+      expect(parts[0].content.split('\n')).toHaveLength(2) // header + 1 valid row
+    })
+  })
+
+  describe('buildExportFileName', () => {
+    it('builds a sanitized file name', () => {
+      expect(buildExportFileName('my-org', '202606')).toBe('my-org-202606.csv')
+    })
+
+    it('sanitizes special characters in the identifier', () => {
+      expect(buildExportFileName('My Org / Team!', '202606')).toBe('My-Org-Team-202606.csv')
+    })
+
+    it('falls back when identifier sanitizes to empty', () => {
+      expect(buildExportFileName('***', '202606')).toBe(`${FALLBACK_FILE_PREFIX}-202606.csv`)
+    })
+  })
+
+  describe('getExportFilesForUploadedCsv', () => {
+    it('produces one file per month with sensible names', () => {
+      const csv = `"date","username","organization"
+"2026-06-01","user1","liantisit-common"
+"2026-07-05","user2","liantisit-common"`
+      const files = getExportFilesForUploadedCsv(csv)
+      expect(files).toHaveLength(2)
+      expect(files.map(f => f.fileName)).toEqual([
+        'liantisit-common-202606.csv',
+        'liantisit-common-202607.csv',
+      ])
+    })
+
+    it('produces empty list for CSVs without a date column', () => {
+      const csv = `"foo","bar"
+"1","2"`
+      expect(getExportFilesForUploadedCsv(csv)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Why

Users can already upload multiple CSV files at once and have them merged for visualization, but there was no way to get that data back out. This adds an **"Export Uploaded Files"** button that re-downloads the originally uploaded data as separate, sensibly-named CSV files.

## Key finding

The new CSV format does **not** contain an `enterprise` field. The only organization-level identifiers available are `organization` and `cost_center_name` (the legacy format has neither). Naming therefore picks the best available identifier per file, in priority order:

`organization` > `cost_center_name` > generic fallback prefix `copilot-usage`

Combined with the month derived from the data, exported files are named:

```
<identifier>-YYYYMM.csv
```

## Approach

- `src/lib/csv-export.ts` (new): given one uploaded file's raw CSV content, splits its rows by calendar month (using the file's date/timestamp column) and determines the naming identifier. Original header and row text are preserved byte-for-byte — no re-serialization of parsed values — keeping the exported files a faithful subset of what was uploaded. If a file spans multiple months, it's split into one CSV per month (simplest, most predictable behavior).
- `src/App.tsx`: tracks each uploaded file's raw content in state, and adds an "Export Uploaded Files" button (next to "Upload New Files") that generates and downloads one CSV per file-month via a Blob + anchor download.
- `src/test/csv-export.test.ts` (new): 14 tests covering identifier selection (organization, cost_center_name, and fallback), month splitting, filename sanitization, and end-to-end export generation.

## Validation

- `npm run test`: 253 passing (1 pre-existing, unrelated smoke test is flaky only under full-suite load and passes in isolation — not affected by this change).
- `npm run build`: succeeds cleanly.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>